### PR TITLE
Add PUT /build/:buildId/executions to store executions against an existing build

### DIFF
--- a/app/controllers/build.controller.js
+++ b/app/controllers/build.controller.js
@@ -318,6 +318,50 @@ exports.update = (req, res) => {
     }).catch((err) => handleError(err, res));
 };
 
+exports.addExecutions = (req, res) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(422).json({ errors: errors.array() });
+  }
+  const { buildId } = req.params;
+  const { executions } = req.body;
+  return Build.findById(buildId)
+    .then((existingBuild) => {
+      if (!existingBuild) {
+        throw new NotFoundError(`No build found with id ${buildId}`);
+      }
+      if (!authMiddleware.hasTeamAccess(req.user, existingBuild.team)) {
+        throw new ForbiddenError('You do not have access to this build');
+      }
+      const testExecutions = executions
+        .map((execution) => buildMetricsUtils.buildExecution(execution, existingBuild));
+      return Execution.insertMany(testExecutions)
+        .then((savedExecutions) => buildMetricsUtils
+          .addExecutionsToBuild(existingBuild, savedExecutions))
+        .catch(async (err) => {
+          // Unlike create, the build may already hold executions and screenshots, so only the
+          // executions from this failed batch are removed - the caller retries the batch.
+          log(`Failed to add executions to build ${buildId}, rolling back batch: ${err.message}`);
+          const batchIds = testExecutions.map((execution) => execution._id);
+          await Execution.deleteMany({ _id: { $in: batchIds } }).exec();
+          throw err;
+        });
+    })
+    .then(() => Build
+      .findOne({ _id: buildId })
+      .populate('team')
+      .populate('environment')
+      .populate('phase')
+      .populate('suites.executions')
+      .lean()
+      .exec())
+    .then((updatedBuild) => {
+      log(`Added ${executions.length} execution(s) to build ${buildId}`);
+      return res.status(200).send(updatedBuild);
+    })
+    .catch((err) => handleError(err, res));
+};
+
 exports.setKeep = (req, res) => {
   const errors = validationResult(req);
   if (!errors.isEmpty()) {

--- a/app/routes/build.routes.js
+++ b/app/routes/build.routes.js
@@ -141,6 +141,35 @@ module.exports = (app, path) => {
       .isBoolean(),
   ], buildController.setKeep);
 
+  app.put(`${path}/build/:buildId/executions`, [
+    param('buildId')
+      .exists()
+      .isMongoId(),
+    // Mirrors the validation POST /build applies to its optional executions array, but here
+    // at least one execution is required as adding nothing to an existing build is a no-op.
+    check('executions')
+      .exists()
+      .custom((executionsArray) => Array.isArray(executionsArray) && executionsArray.length > 0)
+      .withMessage('At least one execution is required'),
+    check('executions.*.title')
+      .exists()
+      .isString()
+      .isLength({ max: 150 })
+      .withMessage('Max length for test title is 150 characters'),
+    check('executions.*.suite')
+      .exists()
+      .isString()
+      .isLength({ max: 150 })
+      .withMessage('Max length for suite name is 150 characters'),
+    check('executions.*.platforms').optional().isArray(),
+    check('executions.*.platforms.*.platformName').optional().isString(),
+    check('executions.*.platforms.*.platformVersion').optional().isString(),
+    check('executions.*.platforms.*.browserName').optional().isString(),
+    check('executions.*.platforms.*.browserVersion').optional().isString(),
+    check('executions.*.platforms.*.deviceName').optional().isString(),
+    check('executions.*.platforms.*.userAgent').optional().isString(),
+  ], buildController.addExecutions);
+
   app.put(`${path}/build/:buildId/artifacts`, [
     param('buildId').isMongoId(),
     check('artifacts')

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -1139,6 +1139,69 @@
                 }
             }
         },
+        "/build/{buildId}/executions": {
+            "parameters": [
+                {
+                    "name": "buildId",
+                    "in": "path",
+                    "required": true,
+                    "description": "ID of build that we want to add the executions to.",
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "put": {
+                "summary": "Adds test executions to the build with the given ID",
+                "description": "Stores all the given test executions against an existing build in a single call. Executions are grouped into suites by their 'suite' name and the build metrics are recalculated. Use this to report a whole test run at the end, once any screenshots have been uploaded individually.",
+                "tags": [
+                    "Build"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "executions"
+                                ],
+                                "properties": {
+                                    "executions": {
+                                        "type": "array",
+                                        "minItems": 1,
+                                        "items": {
+                                            "$ref": "#/components/schemas/BuildExecution"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "description": "Executions you want to store against the build with the given ID."
+                },
+                "responses": {
+                    "200": {
+                        "description": "Build is updated with the given executions.",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/StoredBuild"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Build not found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/DefaultResponse"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/build/{buildId}/artifacts": {
             "parameters": [
                 {

--- a/test/build.tests.js
+++ b/test/build.tests.js
@@ -15,6 +15,7 @@ let phase;
 let createdBuild;
 let buildWithExecutions;
 let emptyExecutionsBuild;
+let batchUpdatedBuild;
 let request;
 
 describe('Build API Tests', () => {
@@ -61,6 +62,10 @@ describe('Build API Tests', () => {
     }
     if (emptyExecutionsBuild) {
       Build.findOneAndRemove({ _id: emptyExecutionsBuild._id }).exec();
+    }
+    if (batchUpdatedBuild) {
+      Execution.deleteMany({ build: batchUpdatedBuild._id }).exec();
+      Build.findOneAndRemove({ _id: batchUpdatedBuild._id }).exec();
     }
   });
 
@@ -200,6 +205,145 @@ describe('Build API Tests', () => {
           res.body.suites.should.have.length(0);
           return done();
         });
+    });
+  });
+
+  describe('PUT /build/:buildId/executions', () => {
+    it('successfully add executions to an existing build in a single call', (done) => {
+      const start = new Date();
+      const end = new Date(start.getTime() + 1000);
+      const createBuildRequest = {
+        environment: environment.name,
+        team: team.name,
+        name: 'build-unit-testing-build-batch-executions',
+        component: team.components[0].name,
+        start,
+      };
+      request
+        .post(`${baseUrl}build`)
+        .send(createBuildRequest)
+        .set('Accept', 'application/json')
+        .expect(201)
+        .end((createErr, createRes) => {
+          if (createErr) return done(createErr);
+          batchUpdatedBuild = createRes.body;
+          const addExecutionsRequest = {
+            executions: [
+              {
+                title: 'passing-test',
+                suite: 'suite-one',
+                start,
+                end,
+                actions: [{
+                  name: 'action-one',
+                  steps: [{
+                    name: 'step-one', status: 'PASS', timestamp: start,
+                  }],
+                }],
+              },
+              {
+                title: 'failing-test',
+                suite: 'suite-two',
+                start,
+                end,
+                actions: [{
+                  name: 'action-one',
+                  steps: [{
+                    name: 'step-one', status: 'FAIL', timestamp: end,
+                  }],
+                }],
+              },
+            ],
+          };
+          return request
+            .put(`${baseUrl}build/${batchUpdatedBuild._id}/executions`)
+            .send(addExecutionsRequest)
+            .set('Accept', 'application/json')
+            .expect('Content-Type', /json/)
+            .expect(200)
+            .end((err, res) => {
+              if (err) return done(err);
+              // executions should be grouped into suites by their suite name
+              res.body.suites.should.have.length(2);
+              const suiteOne = res.body.suites.find((suite) => suite.name === 'suite-one');
+              const suiteTwo = res.body.suites.find((suite) => suite.name === 'suite-two');
+              suiteOne.executions.should.have.length(1);
+              suiteTwo.executions.should.have.length(1);
+              // and the build metrics should be rolled up from them
+              res.body.result.PASS.should.equal(1);
+              res.body.result.FAIL.should.equal(1);
+              res.body.status.should.equal('FAIL');
+              return done();
+            });
+        });
+    });
+
+    it('successfully merge executions into the suites of earlier calls', (done) => {
+      const start = new Date();
+      const end = new Date(start.getTime() + 1000);
+      const addExecutionsRequest = {
+        executions: [
+          {
+            title: 'another-passing-test',
+            suite: 'suite-one',
+            start,
+            end,
+            actions: [{
+              name: 'action-one',
+              steps: [{
+                name: 'step-one', status: 'PASS', timestamp: start,
+              }],
+            }],
+          },
+        ],
+      };
+      request
+        .put(`${baseUrl}build/${batchUpdatedBuild._id}/executions`)
+        .send(addExecutionsRequest)
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          res.body.suites.should.have.length(2);
+          const suiteOne = res.body.suites.find((suite) => suite.name === 'suite-one');
+          suiteOne.executions.should.have.length(2);
+          res.body.result.PASS.should.equal(2);
+          res.body.result.FAIL.should.equal(1);
+          return done();
+        });
+    });
+
+    it('respond with 422 when executions is an empty array', (done) => {
+      request
+        .put(`${baseUrl}build/${batchUpdatedBuild._id}/executions`)
+        .send({ executions: [] })
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(422, done);
+    });
+
+    it('respond with 422 when an execution in the array is missing a suite', (done) => {
+      request
+        .put(`${baseUrl}build/${batchUpdatedBuild._id}/executions`)
+        .send({ executions: [{ title: 'no-suite-test' }] })
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(422, done);
+    });
+
+    it('respond with 404 when the build does not exist', (done) => {
+      request
+        .put(`${baseUrl}build/123456789012345678901234/executions`)
+        .send({
+          executions: [{
+            title: 'passing-test',
+            suite: 'suite-one',
+          }],
+        })
+        .set('Accept', 'application/json')
+        .expect('Content-Type', /json/)
+        .expect(404, done);
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds a `PUT /build/:buildId/executions` endpoint that stores all the given test executions against an existing build in a single call, grouping them into suites and recalculating the build metrics (reusing `addExecutionsToBuild`).
- Enables the batch reporting flow for the clients: create the build up-front (so screenshots can be uploaded individually with a build id as the tests run), then store all the executions in one request at the end of the run.
- On failure only the executions from the failed batch are rolled back — the build and its screenshots are left intact so the caller can simply retry the request.
- Mirrors the per-item validation of the executions array on `POST /build`, but requires at least one execution.
- Documents the new endpoint in the swagger spec.

## Testing
- 5 new integration tests covering: adding executions to an existing build, merging into suites created by earlier calls, empty array (422), missing suite (422), and unknown build (404).
- Full suite: 151 passing, 0 failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)